### PR TITLE
Comments console.log calls and improves error reporting.

### DIFF
--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -106,6 +106,7 @@ var Papertrail = exports.Papertrail = function(options) {
                 if (self.loggingEnabled &&
                     (self.totalRetries >= (self.maximumAttempts))) {
                     self.loggingEnabled = false;
+                    self.emit('error', new Error('Max entries eclipsed, disabling buffering'));
                 }
 
             }, self.connectionDelay);


### PR DESCRIPTION
There are some edge cases when people would like to hijack their console.\* functions
to use papertrail under the hood without changing their existing code.
When console is hijacked, winston-papertrail will get into
an infinite loop and will blow the stack.

The reason I commented console.log calls is because they will be usually useful when developing winston-papertrail but not when people are using it in their production systems. In case of errors than can be caught in development time I switched the code to throw them right-away. In the other cases I'm emitting 'error' so that it's up to the user to choose whether or not they want to listen to them.
