### PR TITLE
inline meta

### DIFF
--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -51,6 +51,9 @@ var Papertrail = exports.Papertrail = function(options) {
     // Delay between normal attempts
     self.connectionDelay = options.connectionDelay || 1000;
 
+    // Handle Exceptions
+    self.handleExceptions = options.handleExceptions || false;
+
     // Maximum delay between attempts
     self.maxDelayBetweenReconnection =
         options.maxDelayBetweenReconnection || 60000;


### PR DESCRIPTION
I added the option to inline the metadata, so it can be better filtered in the papertrail events interface.
