### PR TITLE
only append meta when the object is not empty

### DIFF
--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -243,7 +243,7 @@ Papertrail.prototype.log = function (level, msg, meta, callback) {
         if (typeof meta !== 'object') {
             output += ' ' + meta;
         }
-        else {
+        else if(meta.length > 0) {
             if (this.inlineMeta) {
                 output += ' ' + util.inspect(meta, false, null, self.colorize).replace(/[\n\t]/gm, " ");
             }


### PR DESCRIPTION
{} is add it to the message all the time without this option
