### PR TITLE
Set a TCP keep alive on the socket to prevent silent timeouts on Azure

### DIFF
--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -10,6 +10,7 @@
  */
 
 var os = require('os'),
+    net = require('net'),
     tls = require('tls'),
     util = require('util'),
     winston = require('winston');
@@ -57,6 +58,9 @@ var os = require('os'),
 var Papertrail = exports.Papertrail = function (options) {
 
     var self = this;
+
+    self.KEEPALIVE_INTERVAL = 15*1000;
+
     options = options || {};
 
     self.name = 'Papertrail';
@@ -127,48 +131,51 @@ var Papertrail = exports.Papertrail = function (options) {
         if (self._shutdown) {
             return;
         }
-
-        self.stream = tls.connect(self.port, self.host, {
+        self.socket = net.createConnection(self.port, self.host, function () {
+          self.socket.setKeepAlive(true, self.KEEPALIVE_INTERVAL);
+          self.stream = tls.connect({
+            socket: self.socket,
             rejectUnauthorized: false
-        }, onConnected);
+          }, onConnected);
 
-        self.stream.on('error', function (err) {
-            self.emit('error', err);
+          self.stream.on('error', function (err) {
+              self.emit('error', err);
 
-            // We may be disconnected from the papertrail endpoint for any number of reasons;
-            // i.e. inactivity, network problems, etc, and we need to be resilient against this
-            // that said, we back off reconnection attempts in case Papertrail is truly down
+              // We may be disconnected from the papertrail endpoint for any number of reasons;
+              // i.e. inactivity, network problems, etc, and we need to be resilient against this
+              // that said, we back off reconnection attempts in case Papertrail is truly down
 
-            setTimeout(function () {
+              setTimeout(function () {
 
-                // Increment our retry counts
-                self.currentRetries++;
-                self.totalRetries++;
+                  // Increment our retry counts
+                  self.currentRetries++;
+                  self.totalRetries++;
 
-                // Decay the retry rate exponentially up to max between attempts
-                if ((self.connectionDelay < self.maxDelayBetweenReconnection) &&
-                    (self.currentRetries >= self.attemptsBeforeDecay)) {
-                    self.connectionDelay = self.connectionDelay * 2;
-                    self.currentRetries = 0;
-                }
+                  // Decay the retry rate exponentially up to max between attempts
+                  if ((self.connectionDelay < self.maxDelayBetweenReconnection) &&
+                      (self.currentRetries >= self.attemptsBeforeDecay)) {
+                      self.connectionDelay = self.connectionDelay * 2;
+                      self.currentRetries = 0;
+                  }
 
-                connectStream();
+                  connectStream();
 
-                // Stop buffering messages after a fixed number of retries.
-                // This is to keep the buffer from growing unbounded
-                if (self.loggingEnabled &&
-                    (self.totalRetries >= (self.maximumAttempts))) {
-                    self.loggingEnabled = false;
-                    self.emit('error', new Error('Max entries eclipsed, disabling buffering'));
-                }
+                  // Stop buffering messages after a fixed number of retries.
+                  // This is to keep the buffer from growing unbounded
+                  if (self.loggingEnabled &&
+                      (self.totalRetries >= (self.maximumAttempts))) {
+                      self.loggingEnabled = false;
+                      self.emit('error', new Error('Max entries eclipsed, disabling buffering'));
+                  }
 
-            }, self.connectionDelay);
-        });
+              }, self.connectionDelay);
+          });
 
-        // If we have the stream end, simply reconnect
-        self.stream.on('end', function () {
-            connectStream();
-        });
+          // If we have the stream end, simply reconnect
+          self.stream.on('end', function () {
+              connectStream();
+          });
+      });
     }
 
     function onConnected() {

--- a/test/papertrail-test.js
+++ b/test/papertrail-test.js
@@ -20,7 +20,7 @@ function assertPapertrail (transport) {
   assert.isFunction(transport.log);
 };
 
-var transport = new Papertrail();
+var transport = new Papertrail({host: 'localhost', port: 12345});
 
 vows.describe('winston-papertrail').addBatch({
  "An instance of the Papertrail Transport": {


### PR DESCRIPTION
The current implementation of winston-papertrail is unfirtunately not working when running on a VM on Azure. The specifics of the Azure network requires sockets to send a keepalive, or the connection is silently dropped after 4 minutes of inactivity. This patch changes the way the stream to papertrail is set up and sets a TCP keep alive on the TCP socket.
