### PR TITLE
Send log level to Papertrail

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ There are a number of optional settings:
 - `level` - The log level to use for this transport, defaults to `info`
 - `hostname` - The hostname for your transport, defaults to `os.hostname()`
 - `program` - The program for your transport, defaults to `default`
+- `facility` - The syslog facility for this transport, defaults to `daemon`
 - `logFormat` - A function to format your log message before sending, see below
 - `colorize` - Enable colors in Papertrail, defaults to `false`
 - `inlineMeta` - Inline multi-line messages, defaults to `false`

--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -12,6 +12,7 @@
 var os = require('os'),
     net = require('net'),
     tls = require('tls'),
+    syslogProducer = require('glossy').Produce,
     util = require('util'),
     winston = require('winston');
 
@@ -31,6 +32,8 @@ var os = require('os'),
  * @param {string}      [options.hostname]      name for the logging hostname in Papertrail
  *
  * @param {string}      [options.program]       name for the logging program
+ *
+ * @param {string}      [options.facility]      syslog facility for log messages
  *
  * @param {string}      [options.level]         log level for your transport (info)
  *
@@ -83,6 +86,9 @@ var Papertrail = exports.Papertrail = function (options) {
     // Program is an affordance for Papertrail to name the source of log entries
     self.program = options.program || 'default';
 
+    // Syslog facility to log messages as to Papertrail
+    self.facility = options.facility || 'daemon';
+
     // Send ANSI color codes through to Papertrail
     self.colorize = options.colorize || false;
 
@@ -113,6 +119,8 @@ var Papertrail = exports.Papertrail = function (options) {
 
     // Inline meta flag
     self.inlineMeta = options.inlineMeta || false;
+
+    self.producer = new syslogProducer({ facility: self.facility });
 
     self.currentRetries = 0;
     self.totalRetries = 0;
@@ -331,12 +339,13 @@ Papertrail.prototype.sendMessage = function (hostname, program, level, message) 
             gap = '    ';
         }
 
-        msg += "<25> " +
-            getDate() + ' ' +
-            hostname + ' ' +
-            program + ' ' +
-            self.logFormat(self.colorize ? winston.config.colorize(level) : level, gap + lines[i])
-            + '\r\n';
+        msg += self.producer.produce({
+            severity: level,
+            host: hostname,
+            appName: program,
+            date: new Date(),
+            message: self.logFormat(self.colorize ? winston.config.colorize(level) : level, gap + lines[i])
+        }) + '\r\n';
     }
 
     if (this.stream && this.stream.writable) {
@@ -369,17 +378,3 @@ Papertrail.prototype.close = function() {
         });
     }
 };
-
-// Helper function for date formatting
-function getDate() {
-    var d = new Date();
-    return d.toLocaleString().split(' ')[1] + ' ' +
-        pad2(d.getDate()) + ' ' +
-        pad2(d.getHours()) + ':' +
-        pad2(d.getMinutes()) + ':' +
-        pad2(d.getSeconds());
-}
-
-function pad2(number) {
-    return (number < 10 ? '0' : '') + number;
-}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "peerDependencies": {
     "winston": ">=0.6.x"
   },
+  "dependencies": {
+    "glossy": "^0.1.7"
+  },
   "main": "./lib/winston-papertrail",
   "scripts": {
     "test": "mocha test/*-test.js --spec"

--- a/test/papertrail-test.js
+++ b/test/papertrail-test.js
@@ -103,7 +103,7 @@ describe('connection tests', function() {
 
       listener = function(data) {
         should.exist(data);
-        data.toString().indexOf('default info hello\r\n').should.not.equal(-1);
+        data.toString().indexOf('default - - - info hello\r\n').should.not.equal(-1);
         done();
       }
     });
@@ -130,7 +130,7 @@ describe('connection tests', function() {
 
       listener = function (data) {
         should.exist(data);
-        data.toString().indexOf('default info hello\r\n').should.not.equal(-1);
+        data.toString().indexOf('default - - - info hello\r\n').should.not.equal(-1);
         done();
       }
     });
@@ -157,7 +157,7 @@ describe('connection tests', function() {
 
       listener = function (data) {
         should.exist(data);
-        data.toString().indexOf('default info hello\r\n').should.not.equal(-1);
+        data.toString().indexOf('default - - - info hello\r\n').should.not.equal(-1);
         done();
       }
     });
@@ -184,7 +184,7 @@ describe('connection tests', function() {
 
       listener = function (data) {
         should.exist(data);
-        data.toString().indexOf('default info hello\r\n').should.not.equal(-1);
+        data.toString().indexOf('default - - - info hello\r\n').should.not.equal(-1);
         done();
       }
     });
@@ -211,7 +211,7 @@ describe('connection tests', function() {
 
       listener = function (data) {
         should.exist(data);
-        data.toString().indexOf('default info hello meta object\r\n').should.not.equal(-1);
+        data.toString().indexOf('default - - - info hello meta object\r\n').should.not.equal(-1);
         done();
       }
     });
@@ -293,7 +293,7 @@ describe('connection tests', function() {
 
       listener = function (data) {
         should.exist(data);
-        data.toString().indexOf('default info hello\r\n').should.not.equal(-1);
+        data.toString().indexOf('default - - - info hello\r\n').should.not.equal(-1);
         done();
       }
     });


### PR DESCRIPTION
Currently, every log line sent to Papertrail is prefixed with [&lt;26>](https://github.com/kenperkins/winston-papertrail/blob/35867e421c8d3807060326172920ceb171f7ba85/lib/winston-papertrail.js#L334), which corresponds to the syslog code for facility:daemon and severity:alert. Papertrail allows searching based on these fields, so it would be nice to pass other values.

This patch replaces the static syslog generator with [glossy](https://www.npmjs.com/package/glossy). It's a breaking change, since the log severity now gets passed to Papertrail, and the syslog format now conforms to [RFC 5424](https://tools.ietf.org/html/rfc5424). However, since you can both search and change CSS styling in Papertrail based on log facility/severity, it seemed worth publishing.
