### PR TITLE
inline JSON option

### DIFF
--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -58,6 +58,8 @@ var os = require('os'),
  *
  * @param {Boolean}     [options.inlineMeta]        inline multi-line messages (false)
  *
+ * @param {Boolean}     [options.inlineJson]        inline multi-line messages as parseable json (false)
+ *
  * @type {Function}
  */
 var Papertrail = exports.Papertrail = function (options) {
@@ -119,6 +121,9 @@ var Papertrail = exports.Papertrail = function (options) {
 
     // Inline meta flag
     self.inlineMeta = options.inlineMeta || false;
+
+    // Inline Json
+    self.inlineJson = options.inlineJson || false;
 
     self.producer = new syslogProducer({ facility: self.facility });
 
@@ -289,6 +294,8 @@ Papertrail.prototype.log = function (level, msg, meta, callback) {
         else if (meta) {
             if (this.inlineMeta) {
                 output += ' ' + util.inspect(meta, false, null, self.colorize).replace(/[\n\t]\s*/gm, " ");
+            } else if (this.inlineJson) {
+                output += JSON.stringify(meta);
             }
             else {
                 output += '\n' + util.inspect(meta, false, null, self.colorize);

--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -295,7 +295,9 @@ Papertrail.prototype.log = function (level, msg, meta, callback) {
             if (this.inlineMeta) {
                 output += ' ' + util.inspect(meta, false, null, self.colorize).replace(/[\n\t]\s*/gm, " ");
             } else if (this.inlineJson) {
-                output += JSON.stringify(meta);
+                var metaObject = winston.clone(meta) || {};
+                metaObject.level = level;
+                output += JSON.stringify(metaObject);
             }
             else {
                 output += '\n' + util.inspect(meta, false, null, self.colorize);


### PR DESCRIPTION
adds an option {inlineJson: true} that will log to papertrail with parseable json, defaults to false and inlineMeta takes precedence:

info {"status":200,"duration":367,"path":"/users/","method":"GET","user":"jj@test.local","ip":"127.0.0.1", "level": "info"} 
