### PR TITLE
Call winston.Transport constructor to initialize parent fields

### DIFF
--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -63,6 +63,7 @@ var os = require('os'),
 var Papertrail = exports.Papertrail = function (options) {
 
     var self = this;
+    winston.Transport.call(self, options);
 
     self._KEEPALIVE_INTERVAL = 15 * 1000;
 


### PR DESCRIPTION
I ran across an error when handleExceptions:true and colorize:true are both set, and the global exception handler is triggered. It's related to a field which has been added to the winston.Transport constructor, but is not set the Papertrail constructor. The other transports call the parent constructor to take care of it, and this little patch does the same.

Test script:

```javascript
var winston = require('winston');
var Papertrail = require('winston-papertrail').Papertrail;
var logger = new winston.Logger({
  transports: [
    new Papertrail({
      host: process.env.PAPERTRAIL_HOST,
      port: process.env.PAPERTRAIL_PORT,
      colorize: true,
      handleExceptions: true
    })
  ],
  exitOnError: true
});
throw new Error("Bye");
```

Exception trace:

    /home/ec2-user/bug/node_modules/winston/lib/winston/config.js:26
      } else if (allColors[level].match(/\s/)) {
                                  ^
    TypeError: Cannot call method 'match' of undefined
        at Object.config.colorize (/home/ec2-user/bug/node_modules/winston/lib/winston/config.js:26:31)
        at Papertrail.sendMessage (/home/ec2-user/bug/node_modules/winston-papertrail/lib/winston-papertrail.js:348:68)
        at Papertrail.log (/home/ec2-user/bug/node_modules/winston-papertrail/lib/winston-papertrail.js:300:10)
        at Transport.logException (/home/ec2-user/bug/node_modules/winston/lib/winston/transports/transport.js:124:8)
        at logAndWait (/home/ec2-user/bug/node_modules/winston/lib/winston/logger.js:631:15)
        at /home/ec2-user/bug/node_modules/winston/node_modules/async/lib/async.js:125:13
        at Array.forEach (native)
        at _each (/home/ec2-user/bug/node_modules/winston/node_modules/async/lib/async.js:46:24)
        at Object.async.each (/home/ec2-user/bug/node_modules/winston/node_modules/async/lib/async.js:124:9)
        at Logger._uncaughtException (/home/ec2-user/bug/node_modules/winston/lib/winston/logger.js:654:9)