### PR TITLE
map to severity level directly, since glossy supports numerical as well.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ There are a number of optional settings:
 - `hostname` - The hostname for your transport, defaults to `os.hostname()`
 - `program` - The program for your transport, defaults to `default`
 - `facility` - The syslog facility for this transport, defaults to `daemon`
+- `useNpmStyleLogLevels` - Use NPM-style log levels, and map them to syslog levels via `npmLevelMap`, defaults to `false`
+- `npmLevelMap` - An object, with attributes mapping NPM log levels to numerical syslog RFCs severity levels, defaults to `silly` & `debug` as `7`, `verbose` & `info` as `6`, `warn` as `4`, and `error` as 3
 - `logFormat` - A function to format your log message before sending, see below
 - `colorize` - Enable colors in Papertrail, defaults to `false`
 - `inlineMeta` - Inline multi-line messages, defaults to `false`

--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -37,7 +37,10 @@ var os = require('os'),
  *
  * @param {string}      [options.level]         log level for your transport (info)
  *
- * @param {object}      [options.npmLevelMap    mapping of npm log level to numerical syslog RFCs severity level
+ * @param {Boolean}     [options.useNpmStyleLogLevels]    use NPM-style log levels,
+ *                                                        and map them to syslog levels via `npmLevelMap` (false)
+ *
+ * @param {object}      [options.npmLevelMap]    mapping of npm log level to numerical syslog RFCs severity level
  *
  * @param {Function}    [options.logFormat]     function to format your log message before sending
  *
@@ -73,6 +76,7 @@ var Papertrail = exports.Papertrail = function (options) {
     self.name = 'Papertrail';
     self.level = options.level || 'info';
 
+    self.useNpmStyleLogLevels = options.useNpmStyleLogLevels || false;
     self.npmLevelMap = options.npmLevelMap ||
     {
         silly: 7,
@@ -352,7 +356,7 @@ Papertrail.prototype.sendMessage = function (hostname, program, level, message) 
         }
 
         msg += self.producer.produce({
-            severity: self.npmLevelMap[level],
+            severity: self.useNpmStyleLogLevels && self.npmLevelMap[level] ? self.npmLevelMap[level] : level,
             host: hostname,
             appName: program,
             date: new Date(),

--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -37,6 +37,8 @@ var os = require('os'),
  *
  * @param {string}      [options.level]         log level for your transport (info)
  *
+ * @param {object}      [options.npmLevelMap    mapping of npm log level to numerical syslog RFCs severity level
+ *
  * @param {Function}    [options.logFormat]     function to format your log message before sending
  *
  * @param {Number}      [options.attemptsBeforeDecay]       how many reconnections should
@@ -70,6 +72,16 @@ var Papertrail = exports.Papertrail = function (options) {
 
     self.name = 'Papertrail';
     self.level = options.level || 'info';
+
+    self.npmLevelMap = options.npmLevelMap ||
+    {
+        silly: 7,
+        debug: 7,
+        verbose: 6,
+        info: 6,
+        warn: 4,
+        error: 3
+    };
 
     // Papertrail Service Host
     self.host = options.host;
@@ -340,7 +352,7 @@ Papertrail.prototype.sendMessage = function (hostname, program, level, message) 
         }
 
         msg += self.producer.produce({
-            severity: level,
+            severity: self.npmLevelMap[level],
             host: hostname,
             appName: program,
             date: new Date(),


### PR DESCRIPTION
Add map option for mapping npm levels to syslog severity. Fixes #33.
