### PR TITLE
fix logging of error objects.

### DIFF
--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -265,7 +265,9 @@ Papertrail.prototype.log = function (level, msg, meta, callback) {
         meta = false;
     }
 
-    if  (meta && typeof meta === 'object' && Object.keys(meta).length === 0) {
+    if  (meta && typeof meta === 'object' && (Object.keys(meta).length === 0)
+		&& (!util.isError(meta)))
+	{
         meta = false;
     }
 


### PR DESCRIPTION
fixes an error where

```
var foo = new Error("something");

// Foo is not relayed to Papertrail.
logger.log("test, foo);
```
