### PR TITLE
Enables custom log levels and defaults to npm levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ There are a number of optional settings:
 
 - `disableTls` - set to `true` to disable TLS on your transport. Defaults to `false`
 - `level` - The log level to use for this transport, defaults to `info`
+- `levels` - A custom mapping of log levels strings to severity levels, defaults to the mapping of `npm` levels to RFC5424 severities
 - `hostname` - The hostname for your transport, defaults to `os.hostname()`
 - `program` - The program for your transport, defaults to `default`
 - `facility` - The syslog facility for this transport, defaults to `daemon`

--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -37,6 +37,8 @@ var os = require('os'),
  *
  * @param {string}      [options.level]         log level for your transport (info)
  *
+ * @param {string}      [options.levels]        custom mapping of log levels (npm levels to RFC5424 severities)
+ *
  * @param {Function}    [options.logFormat]     function to format your log message before sending
  *
  * @param {Number}      [options.attemptsBeforeDecay]       how many reconnections should
@@ -70,6 +72,16 @@ var Papertrail = exports.Papertrail = function (options) {
 
     self.name = 'Papertrail';
     self.level = options.level || 'info';
+
+    // Default npm log levels
+    self.levels = options.levels || {
+        silly: 7,
+        debug: 7,
+        verbose: 7,
+        info: 6,
+        warn: 4,
+        error: 3
+    };
 
     // Papertrail Service Host
     self.host = options.host;
@@ -342,7 +354,7 @@ Papertrail.prototype.sendMessage = function (hostname, program, level, message) 
         }
 
         msg += self.producer.produce({
-            severity: level,
+            severity: self.levels[level] ? self.levels[level] : level,
             host: hostname,
             appName: program,
             date: new Date(),
@@ -368,7 +380,7 @@ Papertrail.prototype.close = function() {
     var self = this;
 
     self._shutdown = true;
-    
+
     if (self.stream) {
         self.stream.end();
     }


### PR DESCRIPTION
@kenperkins this PR is similar to #36 but instead sticks to `winston` convention by defaulting to `npm` log levels and accepting a `levels` object to customize log levels. It will also fix #33 as well.