### PR TITLE
logFormat now receives meta

### DIFF
--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -298,7 +298,7 @@ Papertrail.prototype.log = function (level, msg, meta, callback) {
         }
     }
 
-    this.sendMessage(this.hostname, this.program, level, output);
+    this.sendMessage(this.hostname, this.program, level, output, meta);
 
     callback(null, true);
 };
@@ -313,7 +313,7 @@ Papertrail.prototype.log = function (level, msg, meta, callback) {
  * @param {String}    level        Log level of the message
  * @param {String}    message        The message to deliver
  */
-Papertrail.prototype.sendMessage = function (hostname, program, level, message) {
+Papertrail.prototype.sendMessage = function (hostname, program, level, message, meta) {
 
     var self = this,
         lines = [],
@@ -346,7 +346,7 @@ Papertrail.prototype.sendMessage = function (hostname, program, level, message) 
             host: hostname,
             appName: program,
             date: new Date(),
-            message: self.logFormat(self.colorize ? winston.config.colorize(level) : level, gap + lines[i])
+            message: self.logFormat(self.colorize ? winston.config.colorize(level) : level, gap + lines[i], meta)
         }) + '\r\n';
     }
 

--- a/test/papertrail-test.js
+++ b/test/papertrail-test.js
@@ -218,6 +218,39 @@ describe('connection tests', function() {
       }
     });
 
+    it('should pass meta to logFormat', function (done) {
+      var pt = new Papertrail({
+        host: 'localhost',
+        port: 23456,
+        attemptsBeforeDecay: 0,
+        connectionDelay: 10000,
+        logFormat: function(level, message, meta) {
+          return 'META: ' + meta.answer;
+        }
+      });
+
+      pt.on('error', function (err) {
+        should.not.exist(err);
+      });
+
+      pt.on('connect', function () {
+        var meta = {
+          answer: 42
+        };
+        (function() {
+          pt.log('info', 'message', meta, function () {
+
+          });
+        }).should.not.throw();
+      });
+
+      listener = function (data) {
+        should.exist(data);
+        data.toString().indexOf('META: 42\r\n').should.not.equal(-1);
+        done();
+      }
+    });
+
     // TODO need to fix the TLS Server to reject new sockets that are not over tls
     it.skip('should fail to connect without tls', function (done) {
       var pt = new Papertrail({


### PR DESCRIPTION
This PR exposes meta to `logFormat` so it can be used in the custom `logFormat` override.