### PR TITLE
Write buffered events before new events

### DIFF
--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -223,11 +223,7 @@ var Papertrail = exports.Papertrail = function (options) {
 
         self.emit('connect', 'Connected to Papertrail at ' + self.host + ':' + self.port);
 
-        // Did we get messages buffered
-        if (self.buffer.length > 0) {
-            self.stream.write(self.buffer);
-            self.buffer = '';
-        }
+        self.processBuffer();
     }
 };
 
@@ -351,10 +347,19 @@ Papertrail.prototype.sendMessage = function (hostname, program, level, message) 
     }
 
     if (this.stream && this.stream.writable) {
+        this.processBuffer();
         this.stream.write(msg);
     }
     else if (this.loggingEnabled && this.buffer.length < this.maxBufferSize) {
         this.buffer += msg;
+    }
+};
+
+Papertrail.prototype.processBuffer = function () {
+    // Did we have buffered messages?
+    if (this.buffer.length > 0) {
+        this.stream.write(this.buffer);
+        this.buffer = '';
     }
 };
 
@@ -368,7 +373,7 @@ Papertrail.prototype.close = function() {
     var self = this;
 
     self._shutdown = true;
-    
+
     if (self.stream) {
         self.stream.end();
     }

--- a/test/papertrail-test.js
+++ b/test/papertrail-test.js
@@ -108,6 +108,38 @@ describe('connection tests', function() {
       }
     });
 
+    it('should write buffered events before new events', function (done) {
+      var pt = new Papertrail({
+        host: 'localhost',
+        port: 23456,
+        attemptsBeforeDecay: 0,
+        connectionDelay: 10000
+      });
+
+      pt.log('info', 'first', {}, function () {
+
+      });
+
+      pt.on('error', function (err) {
+        should.not.exist(err);
+      });
+
+      pt.on('connect', function () {
+        (function () {
+          pt.log('info', 'second', {}, function () {
+
+          });
+        }).should.not.throw();
+      });
+
+      listener = function (data) {
+        should.exist(data);
+        var lines = data.toString().split('\r\n');
+        lines[0].should.match(/first/);
+        done();
+      }
+    });
+
     it('should support object meta', function (done) {
       var pt = new Papertrail({
         host: 'localhost',


### PR DESCRIPTION
Events that are logged after the connection is made, but before the onConnect callback is called will be sent before the before the buffered events.

This PR changes the code to always process the buffer before writing new events.
