### PR TITLE
Adding `flushOnClose` option.

### DIFF
--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -58,6 +58,8 @@ var os = require('os'),
  *
  * @param {Boolean}     [options.inlineMeta]        inline multi-line messages (false)
  *
+ * @param {Boolean}     [options.flushOnClose]      send remaining messages before closing (false)
+ *
  * @type {Function}
  */
 var Papertrail = exports.Papertrail = function (options) {
@@ -120,6 +122,9 @@ var Papertrail = exports.Papertrail = function (options) {
 
     // Inline meta flag
     self.inlineMeta = options.inlineMeta || false;
+
+    // Send remaining messages before closing?
+    self.flushOnClose = options.flushOnClose || false;
 
     self.producer = new syslogProducer({ facility: self.facility });
 
@@ -256,7 +261,11 @@ var Papertrail = exports.Papertrail = function (options) {
 
         // Did we get messages buffered
         if (self.buffer.length > 0) {
-            self.stream.write(self.buffer);
+            self.stream.write(self.buffer, function(){
+              if(!self.buffer.length){
+                self.stream.emit('empty');
+              }
+            });
             self.buffer = '';
         }
     }
@@ -359,7 +368,7 @@ Papertrail.prototype.sendMessage = function (hostname, program, level, message) 
     }
 
     // If the incoming message has multiple lines, break them and format each
-    // line as it's own message
+    // line as its own message
     for (var i = 0; i < lines.length; i++) {
 
         // don't send extra message if our message ends with a newline
@@ -381,7 +390,11 @@ Papertrail.prototype.sendMessage = function (hostname, program, level, message) 
     }
 
     if (this.stream && this.stream.writable) {
-        this.stream.write(msg);
+        this.stream.write(msg, function(){
+          if(!self.buffer.length){
+            self.stream.emit('empty');
+          }
+        });
     }
     else if (this.loggingEnabled && this.buffer.length < this.maxBufferSize) {
         this.buffer += msg;
@@ -400,7 +413,20 @@ Papertrail.prototype.close = function() {
     self._shutdown = true;
 
     if (self.stream) {
+
+      if(self.flushOnClose && self.buffer.length){
+
+        self.stream.on('empty', function(){
+          self.close();
+        });
+
+      }
+      else{
+
         self.stream.end();
+
+      }
+
     }
     // if there's no stream yet, that means we're still connecting
     // lets wire a connect handler, and then invoke close again


### PR DESCRIPTION
I had an issue using this library with AWS Lambda.

Because the stream was still open by the time my function returned, the Lambda would time out. However, calling `logger.close()` wasn't helpful because my most recent log message would be lost.

This PR adds an option to `flushOnClose`, which will wait until the buffer is empty before closing the stream.
