### PR TITLE
Execute log callback once stream has been written

### DIFF
--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -340,9 +340,8 @@ Papertrail.prototype.log = function (level, msg, meta, callback) {
         }
     }
 
-    this.sendMessage(this.hostname, this.program, level, output);
+    this.sendMessage(this.hostname, this.program, level, output, callback);
 
-    callback(null, true);
 };
 
 /**
@@ -354,8 +353,9 @@ Papertrail.prototype.log = function (level, msg, meta, callback) {
  * @param {String}    program     Name of the source application
  * @param {String}    level        Log level of the message
  * @param {String}    message        The message to deliver
+ * @param {Function}  callback      callback to be executed when the log has been written to the stream
  */
-Papertrail.prototype.sendMessage = function (hostname, program, level, message) {
+Papertrail.prototype.sendMessage = function (hostname, program, level, message, callback) {
 
     var self = this,
         lines = [],
@@ -393,7 +393,7 @@ Papertrail.prototype.sendMessage = function (hostname, program, level, message) 
     }
 
     if (this.stream && this.stream.writable) {
-        this.stream.write(msg);
+        this.stream.write(msg, callback);
     }
     else if (this.loggingEnabled && this.buffer.length < this.maxBufferSize) {
         this.buffer += msg;


### PR DESCRIPTION
We were having problems with a race condition using AWS lambda where we would log the results just before the `context.succeed` callback was executed, resulting in the log sometimes never being logged as the callback previously didn't wait until the stream had been properly written.

This seems to solve that issue.