### PR TITLE
Patch to try and address #20 / #49 / #56, peacefully log connection errors …

### DIFF
--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -225,7 +225,7 @@ var Papertrail = exports.Papertrail = function (options) {
         // make sure we prevent simultaneous attempts to connect and handle errors
         self._erroring = true;
 
-        self.emit('error', err);
+		self._silentErrorEmitter(err);
 
         // We may be disconnected from the papertrail endpoint for any number of reasons;
         // i.e. inactivity, network problems, etc, and we need to be resilient against this
@@ -244,11 +244,11 @@ var Papertrail = exports.Papertrail = function (options) {
 
             // Stop buffering messages after a fixed number of retries.
             // This is to keep the buffer from growing unbounded
-            if (self.loggingEnabled &&
-                (self.totalRetries >= (self.maximumAttempts))) {
-                    self.loggingEnabled = false;
-                    self.emit('error', new Error('Max entries eclipsed, disabling buffering'));
-            }
+			if (self.loggingEnabled && (self.totalRetries >= (self.maximumAttempts)))
+			{
+				self.loggingEnabled = false;
+				self._silentErrorEmitter(new Error('Max entries eclipsed, disabling buffering'));
+			}
 
             // continue
             self._erroring = false;
@@ -421,4 +421,26 @@ Papertrail.prototype.close = function() {
             self.close();
         });
     }
+};
+
+/**
+ * The goal here is to ignore connection errors by default without triggering an uncaughtException.
+ * You can still bind your own error handler as normal, but if you haven't overridden it, connection errors
+ * will be logged to the console by default.
+ *
+ * Notes: This is meant to fix usability issues #20, and #49
+ *
+ * @param err
+ * @private
+ */
+Papertrail.prototype._silentErrorEmitter = function(err) {
+	var count = this.listeners('error').length;
+	if (count > 0) {
+		// the goal here is to ensure someone is catching this event, instead of potentially
+		// causing the process to exit.
+		this.emit('error', err);
+	}
+	else {
+		console.error('Papertrail connection error: ', err);
+	}
 };

--- a/test/papertrail-test.js
+++ b/test/papertrail-test.js
@@ -33,6 +33,22 @@ describe('connection tests', function() {
       });
     });
 
+    it('should not exit process when it fails to connect', function (done) {
+      var pt = new Papertrail({
+        host: 'this.wont.resolve',
+        port: 12345,
+        attemptsBeforeDecay: 0,
+        connectionDelay: 10000
+      });
+
+		// NOTE!  We intentionally left off the error handler here, this proves
+		// the process won't exit on a connection error.
+
+		setTimeout(function() {
+			done();
+		}, 125);
+    });
+
     it.skip('should timeout', function (done) {
       var pt = new Papertrail({
         host: '8.8.8.8', // TODO Figure out how to enable a timeout test


### PR DESCRIPTION
The goal of this PR is to try and avoid detonating the process when an error handler isn't attached to this module.  When there is no error handler, connection errors or otherwise are logged to the console instead of being emitted.  When there is a listener attached, the errors are emitted instead.

Also the _silentErrorEmitter is a protected function on the module, instead of private, so it can also be extended directly if need be.

I thought about this quite a bit, and I think this solution allows the best default behavior (don't explode by default), while still allowing all the unit tests to pass without modification, and providing the most power to developers.

Really curious to hear feedback / thoughts / concerns.  Thanks!