### PR TITLE
Unref socket

### DIFF
--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -198,19 +198,20 @@ var Papertrail = exports.Papertrail = function (options) {
 
         try {
             if (self.disableTls) {
-                self.stream = net.createConnection(self.port, self.host, onConnected);
-                self.stream.setKeepAlive(true, self._KEEPALIVE_INTERVAL);
+                self.stream = net.createConnection(self.port, self.host, function () {
+                    onConnected(self.stream);
+                });
 
                 wireStreams();
             }
             else {
                 var socket = net.createConnection(self.port, self.host, function () {
-                    socket.setKeepAlive(true, self._KEEPALIVE_INTERVAL);
-
                     self.stream = tls.connect({
                         socket: socket,
                         rejectUnauthorized: false
-                    }, onConnected);
+                    }, function () {
+                        onConnected(socket);
+                    });
 
                     wireStreams();
                 });
@@ -261,7 +262,10 @@ var Papertrail = exports.Papertrail = function (options) {
         }, self.connectionDelay);
     }
 
-    function onConnected() {
+    function onConnected(socket) {
+        socket.setKeepAlive(true, self._KEEPALIVE_INTERVAL);
+        socket.unref();
+
 		// Reset our variables
 		self.loggingEnabled = true;
 		self.currentRetries = 0;

--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -262,9 +262,9 @@ var Papertrail = exports.Papertrail = function (options) {
         }, self.connectionDelay);
     }
 
-    function onConnected(socket) {
-        socket.setKeepAlive(true, self._KEEPALIVE_INTERVAL);
-        socket.unref();
+	function onConnected(socket) {
+		socket.setKeepAlive(true, self._KEEPALIVE_INTERVAL);
+		socket.unref();
 
 		// Reset our variables
 		self.loggingEnabled = true;


### PR DESCRIPTION
This PR adds a call to `unref` on the socket, so that it does not keep the Node process running. It also moves the call to `setKeepAlive` into `onConnected` so that it's not repeated. This fixes issue #54.