### PR TITLE
Add Option to Suppress Metadata sent to Papertrail

### DIFF
--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -142,6 +142,8 @@ var Papertrail = exports.Papertrail = function (options) {
 	self.flushOnClose = options.flushOnClose || false;
 
     self.producer = new syslogProducer({ facility: self.facility });
+	
+    self.suppressMeta = options.suppressMeta || false;
 
     self.currentRetries = 0;
     self.totalRetries = 0;
@@ -305,6 +307,9 @@ winston.transports.Papertrail = Papertrail;
 Papertrail.prototype.log = function (level, msg, meta, callback) {
 
     var self = this;
+	
+    if(self.suppressMeta)
+        meta = false;
 
     // make sure we handle when meta isn't provided
     if (typeof(meta) === 'function' && !callback) {


### PR DESCRIPTION
Adds `suppressMeta` option which defaults to false. When set to true metadata will not be included in the output published to Papertrail.

