### PR TITLE
Enable inlineMeta option

### DIFF
--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -81,6 +81,7 @@ class PapertrailTransport extends Transport {
     this.colorize = options.colorize;
     this.hostname = options.hostname || os.hostname();
     this.program = options.program;
+    this.inlineMeta = options.inlineMeta;
     this.logFormat =
       options.logFormat ||
       function(level, message) {


### PR DESCRIPTION
It was missing in the constructor, so it was always ignored.