### PR TITLE
Use triple-beam symbols to access info object

### DIFF
--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -14,6 +14,7 @@ const os = require('os');
 const tls = require('tls');
 const util = require('util');
 const { EventEmitter } = require('events');
+const { MESSAGE, LEVEL } = require('triple-beam');
 
 const KEEPALIVE_INTERVAL = 15 * 1000;
 
@@ -234,7 +235,9 @@ class PapertrailTransport extends Transport {
     });
 
     // write to Papertrail
-    const { level, message, meta } = info;
+    const level = info[LEVEL];
+    const message = info[MESSAGE];
+    const { meta } = info;
     let output = message;
 
     if (meta) {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint": "^5.11.1",
     "mocha": "^2.0.1",
     "should": "^4.3.0",
+    "triple-beam": "^1.3.0",
     "winston": ">=0.6.x"
   },
   "dependencies": {


### PR DESCRIPTION
Winston uses the `triple-beam` to provide symbols for accessing the `info` object. By accessing the level and message using the string key (via object destructuring) instead of using the symbols, winston-papertrail was not getting the correct value. 

Example: If you define a formatter using the `winston.createLogger` `format` option it will store the formatted message on the info object with the key being the `MESSAGE` symbol from triple-beam not the string 'message'. Therefore when winston-papertrail went to access the message it received the unformatted message.